### PR TITLE
Ensure smartcats works with legacy contract

### DIFF
--- a/packages/gateway/src/constants.ts
+++ b/packages/gateway/src/constants.ts
@@ -6,6 +6,7 @@ export const PRIVATE_KEY = process.env.PRIVATE_KEY;
 export const DATABASE_CONNECTION = process.env.DATABASE_CONNECTION; //http://scriptproxy.smarttokenlabs.com:8083
 export const PORT = process.env.PORT;
 export const TTL = process.env.TTL;
+export const SMARTCATS_RESOLVER = "0x6a844646443f29dF2Fd47F92E3520b61F3FC0754";
 
 if (!PRIVATE_KEY) throw new Error("No private key provided");
 if (!DATABASE_CONNECTION) throw new Error("No Database link");

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -6,6 +6,7 @@ import { abi as IResolverService_abi } from '@ensdomains/offchain-resolver-contr
 import { abi as Resolver_abi } from '@ensdomains/ens-contracts/artifacts/contracts/resolvers/Resolver.sol/Resolver.json';
 import fetch from 'node-fetch';
 import { ETH_COIN_TYPE } from './utils';
+import { SMARTCATS_RESOLVER } from './constants';
 const Resolver = new ethers.utils.Interface(Resolver_abi);
 
 interface DatabaseResult {
@@ -130,9 +131,9 @@ export function makeServer(signer: ethers.utils.SigningKey, dataPath: string, tt
       type: 'resolve',
       func: async ([encodedName, data]: Result, request) => {
         const name = decodeDnsName(Buffer.from(encodedName.slice(2), 'hex'));
-        //const resolverAddr: string = request.to.toString();
+        const resolverAddr: string = request.to.toString();
         //console.log(`name: ${name} dataPath ${dataPath} ${data} ${request?.data}`);
-        //console.log(`Request: ${resolverAddr}`);
+        console.log(`Request: ${resolverAddr}`);
 
         var chainIdToUse: number;
 
@@ -144,7 +145,12 @@ export function makeServer(signer: ethers.utils.SigningKey, dataPath: string, tt
           //console.log(`${chainId}`);
           chainIdToUse = chainId;
         } catch (e) {
-          chainIdToUse = 8887; //put this onto a chain that doesn't exist (this will be logged safely into that database so as not to overwrite anything)
+          //is this coming from the SmartCats mainnet resolver?
+          if (resolverAddr.toLowerCase() === SMARTCATS_RESOLVER.toLowerCase()) {
+            chainIdToUse = 1; // Mainnet smartcats resolver - this contract doesn't report chainId
+          } else {
+            chainIdToUse = 8887; //put this onto a chain that doesn't exist (this will be logged safely into that database so as not to overwrite anything)
+          }
         }
 
         // Query the database


### PR DESCRIPTION
This allows the legacy resolver for smartcats to still work, despite not reporting the chainId. We just take the resolver address.